### PR TITLE
Missing parameters

### DIFF
--- a/Components/ReportsController.vb
+++ b/Components/ReportsController.vb
@@ -553,6 +553,11 @@ Namespace DotNetNuke.Modules.Reports
         Public Shared Function BuildParameters(ByVal SrcModule As PortalModuleBase, ByVal Report As ReportInfo) As Dictionary(Of String, Object)
             Dim dict As New Dictionary(Of String, Object)
 
+            Dim params As String() = { }
+            If Not String.IsNullOrEmpty(Report.Parameters.Trim()) Then
+                params = Report.Parameters.Split(","c)
+            End If
+
             If SrcModule IsNot Nothing Then
 
                 dict.Add("PortalID", SrcModule.PortalId)
@@ -560,19 +565,24 @@ Namespace DotNetNuke.Modules.Reports
                 dict.Add("ModuleID", SrcModule.ModuleId)
                 dict.Add("UserID", SrcModule.UserId)
 
-                If Not String.IsNullOrEmpty(Report.Parameters.Trim()) Then
+                For Each param As String In params
+                    ' Get the value from the request
+                    Dim value As Object = SrcModule.Request.Params(param)
 
-                    Dim params As String() = Report.Parameters.Split(","c)
+                    ' Add the parameter
+                    dict.Add("url_" + param, If(value, DbNull.Value))
+                Next
 
-                    For Each param As String In params
-                        ' Get the value from the request
-                        Dim value As String = SrcModule.Request.Params(param)
+            Else
 
-                        ' Add the parameter
-                        dict.Add("url_" + param, value)
-                    Next
+                dict.Add("PortalID", DbNull.Value)
+                dict.Add("TabID", DbNull.Value)
+                dict.Add("ModuleID", DbNull.Value)
+                dict.Add("UserID", DbNull.Value)
 
-                End If
+                For Each param As String In params
+                    dict.Add("url_" + param, DbNull.Value)
+                Next
 
             End If
 

--- a/Components/ReportsController.vb
+++ b/Components/ReportsController.vb
@@ -575,9 +575,10 @@ Namespace DotNetNuke.Modules.Reports
 
             Else
 
-                dict.Add("PortalID", DbNull.Value)
-                dict.Add("TabID", DbNull.Value)
-                dict.Add("ModuleID", DbNull.Value)
+                Dim moduleInfo = New ModuleController().GetModule(Report.ModuleID)
+                dict.Add("PortalID", moduleInfo.PortalID)
+                dict.Add("TabID", moduleInfo.TabID)
+                dict.Add("ModuleID", Report.ModuleID)
                 dict.Add("UserID", DbNull.Value)
 
                 For Each param As String In params

--- a/My Project/AssemblyInfo.vb
+++ b/My Project/AssemblyInfo.vb
@@ -2,19 +2,19 @@
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 
-' General Information about an assembly is controlled through the following 
+' General Information about an assembly is controlled through the following
 ' set of attributes. Change these attribute values to modify the information
 ' associated with an assembly.
 
 ' Review the values of the assembly attributes
-<Assembly: AssemblyTitle("DotNetNuke Reports Module")> 
-<Assembly: AssemblyDescription("DotNetNuke Reports Module")> 
-<Assembly: AssemblyCompany("DotNetNuke Corporation")> 
+<Assembly: AssemblyTitle("DotNetNuke Reports Module")>
+<Assembly: AssemblyDescription("DotNetNuke Reports Module")>
+<Assembly: AssemblyCompany("DotNetNuke Corporation")>
 <Assembly: AssemblyProduct("http://www.dotnetnuke.com")>
 <Assembly: AssemblyCopyright("DotNetNuke Reports Module is copyright 2002-2016 by DotNetNuke Corporation. All Rights Reserved")>
-<Assembly: AssemblyTrademark("DotNetNuke")> 
+<Assembly: AssemblyTrademark("DotNetNuke")>
 
-<Assembly: ComVisible(False)> 
+<Assembly: ComVisible(False)>
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM
 <Assembly: Guid("334e9cee-0d47-4d70-924b-b5098a3432cb")>
@@ -22,16 +22,16 @@ Imports System.Runtime.InteropServices
 ' Version information for an assembly consists of the following four values:
 '
 '      Major Version
-'      Minor Version 
+'      Minor Version
 '      Build Number
 '      Revision
 '
-' You can specify all the values or you can default the Build and Revision Numbers 
+' You can specify all the values or you can default the Build and Revision Numbers
 ' by using the '*' as shown below:
-' <Assembly: AssemblyVersion("1.0.*")> 
+' <Assembly: AssemblyVersion("1.0.*")>
 
-<Assembly: AssemblyVersion("5.8.0.0")>
-<Assembly: AssemblyFileVersion("5.8.0.0")>
-<Assembly: WebResource("dnn.reports.js", "text/javascript")> 
-<Assembly: WebResource("CssForm.css", "test/css")> 
-<Assembly: WebResource("CssForm.debug.css", "text/css")> 
+<Assembly: AssemblyVersion("5.7.2.0")>
+<Assembly: AssemblyFileVersion("5.7.2.0")>
+<Assembly: WebResource("dnn.reports.js", "text/javascript")>
+<Assembly: WebResource("CssForm.css", "test/css")>
+<Assembly: WebResource("CssForm.debug.css", "text/css")>

--- a/Reports.dnn
+++ b/Reports.dnn
@@ -1,7 +1,7 @@
 ﻿  <?xml version="1.0" encoding="utf-8" ?>
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DNN_Reports" type="Module" version="5.7.1">
+    <package name="DNN_Reports" type="Module" version="5.7.2">
       <friendlyName>Reports</friendlyName>
       <description>
         The ReportsModule allows users to quickly display data retrieved from many data sources. An extensible architecture allows the use of custom Data Sources and Visualization systems to display data from any tabular data source, in many ways.
@@ -108,7 +108,7 @@
             <assembly>
               <name>DotNetNuke.Modules.Reports.dll</name>
               <sourceFileName>DotNetNuke.Modules.Reports.dll</sourceFileName>
-              <version>05.07.01</version>
+              <version>05.07.02</version>
             </assembly>
           </assemblies>
         </component>
@@ -127,9 +127,9 @@
           <resourceFiles>
             <basePath>DesktopModules\Reports</basePath>
             <resourceFile>
-              <name>Reports_05.07.01_Resources.zip</name>
+              <name>Reports_05.07.02_Resources.zip</name>
               <!-- Without this, the resources file must be in DesktopModules\Reports in the ZIP file too -->
-              <sourceFileName>Reports_05.07.01_Resources.zip</sourceFileName>
+              <sourceFileName>Reports_05.07.02_Resources.zip</sourceFileName>
             </resourceFile>
           </resourceFiles>
         </component>
@@ -307,6 +307,14 @@
             </file>
             <file>
               <name>Reports_05.07.00_Source.zip</name>
+            </file>
+          </files>
+        </component>
+        <component type="Cleanup" version="05.07.02">
+          <files>
+            <basePath>DesktopModules\Reports</basePath>
+            <file>
+              <name>Reports_05.07.01_Resources.zip.manifest</name>
             </file>
           </files>
         </component>

--- a/Reports.vbproj
+++ b/Reports.vbproj
@@ -25,7 +25,7 @@
     </SccAuxPath>
     <SccProvider>
     </SccProvider>
-    <DNNVersion>05.07.01</DNNVersion>
+    <DNNVersion>05.07.02</DNNVersion>
     <DNNPackageOutputPath>Packages</DNNPackageOutputPath>
     <ResourceFileName>$(MSBuildProjectName)_$(DNNVersion)_Resources.zip</ResourceFileName>
     <FileUpgradeFlags>
@@ -373,7 +373,7 @@
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Import Project="$(MSBuildProjectDirectory)\BuildSupport\DotNetNuke.Common.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -1,5 +1,9 @@
-﻿<h2>Reports Module 05.07.01</h2>
-<p>DNN Reports 05.07.01 will work for any DNN version <strong>7.1.2</strong> and up. Full details on the changes can be found in great detail at <a href="http://dnnreports.codeplex.com/workitem/list/basic">http://dnnreports.codeplex.com/workitem/list/basic</a>. </p>
+﻿<h2>Reports Module 05.07.02</h2>
+<p>DNN Reports 05.07.02 will work for any DNN version <strong>7.1.2</strong> and up. Full details on the changes can be found in great detail at <a href="http://dnnreports.codeplex.com/workitem/list/basic">http://dnnreports.codeplex.com/workitem/list/basic</a>. </p>
+<p><strong>Releasenotes 05.07.02</strong></p>
+<p>
+BGFX: Missing parameters (e.g. from the URL) will be sent to the SQL script as <code>NULL</code>, instead of throwing an error.<br />
+</p>
 <p><strong>Releasenotes 05.07.01</strong></p>
 <p>
 ENHA: Token Replacement also works for calculated (normally read only) columns.<br />


### PR DESCRIPTION
When parameters are missing (either because they are supposed to come from the URL and they're missing, or because the report is running via the search indexer, i.e. without a module's context), substitute `DbNull.Value` for that parameter so that the report doesn't error.

Fixes #1 