### PR TITLE
Remove SQL filtering from .html template

### DIFF
--- a/Visualizers/HTML/Visualizer.ascx.cs
+++ b/Visualizers/HTML/Visualizer.ascx.cs
@@ -101,7 +101,7 @@ namespace DotNetNuke.Modules.Reports.Visualizers.Html
                                 var divContent = new HtmlGenericControl("div");
                                 divContent.Attributes["class"] = "DNN_Reports_HTML_Item";
                                 divContent.InnerHtml =
-                                    objSec.InputFilter(rowHtml, PortalSecurity.FilterFlag.MultiLine|PortalSecurity.FilterFlag.NoSQL);
+                                    objSec.InputFilter(rowHtml, PortalSecurity.FilterFlag.MultiLine);
                                 this.pnlContent.Controls.Add(divContent);
                             }
                         }


### PR DESCRIPTION
The SQL filter is stripping dashes out of HTML classes. Example: `class="article-author--jobtitle"` gets filtered to `class="article-author jobtitle"`.

- [x ] Fixes Bug